### PR TITLE
Directly evaluate script as CLI parameter

### DIFF
--- a/file/execute_file.go
+++ b/file/execute_file.go
@@ -9,3 +9,9 @@ func (i *InvContext) RunFile(fileName string) error {
 	log.WithFields(log.Fields{"fileName": fileName}).Debug("Run file")
 	return i.duk.PevalFile(fileName)
 }
+
+// RunString runs the given parameter directly
+func (i *InvContext) RunString(script string) error {
+	log.WithFields(log.Fields{"script": script}).Debug("Run script")
+	return i.duk.PevalString(script)
+}

--- a/help.go
+++ b/help.go
@@ -9,8 +9,8 @@ func parseArguments() map[string]interface{} {
 Usage:
   involucro -h | --help
   involucro --version
-  involucro [-w <path>] [ -H <url> | --host=<url> ] [-v [-v]] [ -f <file> ] [--] <task>...
-  involucro (-n | -s) [-v [-v]] [-f <file>] [--] <task>...
+  involucro [-w <path>] [ -H <url> | --host=<url> ] [-v [-v]] [-f <file> | -e <script>] [--] <task>...
+  involucro (-n | -s) [-v [-v]] [-f <file> | -e <script> ] <task>...
   involucro --wrap=<source-dir> --into-image=<parent-image> --at=<target-dir> --as=<image-id>
 
 Options:
@@ -18,6 +18,7 @@ Options:
   -H, --host=<url>        Set the URL for Docker [default: unix:///var/run/docker.sock].
   --version               Show version.
   -f <file>               Set the control file [default: invfile.js].
+  -e <script>             Evaluate the given script directly.
   -v                      Increase verbosity (use twice for even more messages).
   -n                      Do not really execute commands in Docker, just show them.
   -s                      Instead of executing the commands against Docker, print equivalent shell commands.

--- a/integrationtest/04_parameters.sh
+++ b/integrationtest/04_parameters.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+
+set -e
+
+rm -f __asd
+../involucro -e "inv.task('touch').using('busybox').run('touch', '/source/__asd')" touch
+test -f "__asd"
+rm -f __asd
+
+../involucro -n -e "inv.task('touch').using('busybox').run('touch', '/source/__asd')" touch
+test ! -f "__asd"
+
+../involucro -s -e "inv.task('touch').using('busybox').run('touch', '/source/__asd')" touch
+test ! -f "__asd"
+
+set +e
+../involucro -n -e "inv.task('touch').using('busybox').run('touch', '/source/__asd')" -f invfile.js touch && { echo "Accepted -e ... -f" ; exit 1; }
+set -e

--- a/integrationtest/Makefile
+++ b/integrationtest/Makefile
@@ -1,5 +1,5 @@
 
-all: 01 02
+all: 01 02 04
 
 
 01:
@@ -8,3 +8,6 @@ all: 01 02
 
 02:
 	./02_hello_world.sh
+
+04:
+	./04_parameters.sh

--- a/main.go
+++ b/main.go
@@ -46,7 +46,12 @@ func main() {
 	if arguments["-s"].(bool) {
 		fmt.Println("#!/bin/sh")
 	}
-	ctx.RunFile(arguments["-f"].(string))
+
+	if arguments["-e"] != nil {
+		ctx.RunString(arguments["-e"].(string))
+	} else {
+		ctx.RunFile(arguments["-f"].(string))
+	}
 
 	for _, element := range (arguments["<task>"]).([]string) {
 		steps := ctx.Tasks[element]


### PR DESCRIPTION
Involucro should support a CLI parameter: `-e` that takes a script as single parameter, and executes that. If `-e` is given, `-f` may not be used, and `invfile.js` is not examined.

`involucro -e "inv.task('asd')" asd`
