### PR TITLE
.withHostConfig discards binds without binds being set

### DIFF
--- a/internal/run.go
+++ b/internal/run.go
@@ -240,7 +240,7 @@ func (ubs usingBuilderState) withConfig(l *lua.State) int {
 }
 
 func (ubs usingBuilderState) withHostConfig(l *lua.State) int {
-	ubs.HostConfig = translator.ParseHostConfigFromLuaTable(l)
+	ubs.HostConfig = translator.ParseHostConfigFromLuaTable(l, ubs.HostConfig)
 	return ubs.usingTable(l)
 }
 

--- a/internal/translator/docker_host_config.go
+++ b/internal/translator/docker_host_config.go
@@ -9,12 +9,11 @@ import (
 )
 
 // ParseHostConfigFromLuaTable reads all keys in the currently top-most
-// table from the stack and applies everything it can to a docker.HostConfig.
+// table from the stack and applies everything it can to the given default
+// docker.HostConfig.
 // The comparison is case insensitive by design.
-func ParseHostConfigFromLuaTable(l *lua.State) docker.HostConfig {
+func ParseHostConfigFromLuaTable(l *lua.State, conf docker.HostConfig) docker.HostConfig {
 	lua.CheckType(l, -1, lua.TypeTable)
-
-	conf := docker.HostConfig{}
 
 	l.PushNil()
 	for l.Next(-2) {

--- a/internal/translator/full_test.go
+++ b/internal/translator/full_test.go
@@ -186,7 +186,7 @@ func TestAllPropertiesHostConfig(t *testing.T) {
 	}
 	state.Global("x")
 
-	if actual := ParseHostConfigFromLuaTable(state); !reflect.DeepEqual(actual, expected) {
+	if actual := ParseHostConfigFromLuaTable(state, docker.HostConfig{}); !reflect.DeepEqual(actual, expected) {
 		t.Error("Actual is not equal to expected", actual, expected)
 	}
 }

--- a/internal/translator/unknown_key_test.go
+++ b/internal/translator/unknown_key_test.go
@@ -1,10 +1,11 @@
 package translator
 
 import (
-	"github.com/Shopify/go-lua"
-	"github.com/fsouza/go-dockerclient"
 	"reflect"
 	"testing"
+
+	"github.com/Shopify/go-lua"
+	"github.com/fsouza/go-dockerclient"
 )
 
 func TestUnknownPropertiesConfig(t *testing.T) {
@@ -34,7 +35,7 @@ func TestUnknownPropertiesHostConfig(t *testing.T) {
 	}
 	state.Global("x")
 
-	if actual := ParseHostConfigFromLuaTable(state); !reflect.DeepEqual(actual, expected) {
+	if actual := ParseHostConfigFromLuaTable(state, docker.HostConfig{}); !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Wasn't unchanged: %v != %v", actual, expected)
 	}
 }


### PR DESCRIPTION
`.withHostConfig({ publishallports = true })` should still use the default `bind`.