### PR TITLE
Files read in infile using io.lines are closed too early

### DIFF
--- a/internal/lua_io.go
+++ b/internal/lua_io.go
@@ -59,7 +59,7 @@ func ioLines(l *lua.State) int {
 	return 1
 }
 
-func (iof ioFile) readline(l *lua.State) int {
+func (iof *ioFile) readline(l *lua.State) int {
 	if !iof.sc.Scan() {
 		iof.Close()
 		l.PushNil()


### PR DESCRIPTION
An incorrectly registered finalizer caused files read via `io.lines` to be closed before they are fully read. This problem started to manifest itself with files bigger than *4096* bytes (the default buffer size of a `bufio.Scanner`) and with enough time spent between subsequent line reads.